### PR TITLE
Fix the agent not starting if args are not supplied

### DIFF
--- a/src/main/java/com/github/lookout/metrics/agent/ReportAgent.java
+++ b/src/main/java/com/github/lookout/metrics/agent/ReportAgent.java
@@ -18,7 +18,8 @@ public class ReportAgent {
             host = "unknown-host";
         }
 
-        for (final String reportingHostPort : agentArgs.split(",")) {
+        final String[] reportingHostPorts = (agentArgs != null) ? agentArgs.split(",") : new String[]{null};
+        for (final String reportingHostPort : reportingHostPorts) {
             final HostPortInterval hostPortInterval = new HostPortInterval(reportingHostPort);
             final StatsDClient client = new NonBlockingStatsDClient(host, hostPortInterval.getHost(), hostPortInterval.getPort());
             final StatsdReporter reporter = new StatsdReporter(hostPortInterval, client);


### PR DESCRIPTION
With this fix if -javaagent:$CASSANDRA_HOME/agent-1.1.jar is used without args, the agent starts.