### PR TITLE
Add support for configuring statsd prefix

### DIFF
--- a/src/main/java/com/github/lookout/metrics/agent/HostPortInterval.java
+++ b/src/main/java/com/github/lookout/metrics/agent/HostPortInterval.java
@@ -11,14 +11,27 @@ public class HostPortInterval {
     private final String host;
     private final int port;
     private final int interval;
+    private final String prefix;
 
-    public HostPortInterval(final String hostPortInterval) {
-        if (hostPortInterval == null || hostPortInterval.isEmpty()) {
+    public HostPortInterval(final String hostPortIntervalPrefix) {
+        if (hostPortIntervalPrefix == null || hostPortIntervalPrefix.isEmpty()) {
             this.host = DEFAULT_HOST;
             this.port = DEFAULT_PORT;
             this.interval = DEFAULT_INTERVAL;
+            this.prefix = null;
             return;
         }
+
+        String hostPortInterval;
+        int prefixOffset = hostPortIntervalPrefix.lastIndexOf('/');
+        if (prefixOffset != -1) {
+            this.prefix = hostPortIntervalPrefix.substring(prefixOffset + 1);
+            hostPortInterval = hostPortIntervalPrefix.substring(0, prefixOffset);
+        } else {
+            this.prefix = null;
+            hostPortInterval = hostPortIntervalPrefix;
+        }
+
         int intervalOffset = hostPortInterval.lastIndexOf('@');
         final String hostPort;
         if (intervalOffset == -1) {
@@ -59,6 +72,10 @@ public class HostPortInterval {
 
     public int getInterval() {
         return interval;
+    }
+
+    public String getPrefix() {
+        return prefix;
     }
 
     @Override

--- a/src/main/java/com/github/lookout/metrics/agent/ReportAgent.java
+++ b/src/main/java/com/github/lookout/metrics/agent/ReportAgent.java
@@ -22,7 +22,7 @@ public class ReportAgent {
         final String[] reportingHostPorts = (agentArgs != null) ? agentArgs.split(",") : new String[]{null};
         for (final String reportingHostPort : reportingHostPorts) {
             final HostPortInterval hostPortInterval = new HostPortInterval(reportingHostPort);
-            final StatsDClient client = new NonBlockingStatsDClient(host, hostPortInterval.getHost(), hostPortInterval.getPort());
+            final StatsDClient client = new NonBlockingStatsDClient(hostPortInterval.getPrefix() != null ? hostPortInterval.getPrefix() : host, hostPortInterval.getHost(), hostPortInterval.getPort());
             final StatsdReporter reporter = new StatsdReporter(hostPortInterval, client);
             reporter.start(hostPortInterval.getInterval(), TimeUnit.SECONDS);
         }


### PR DESCRIPTION
I was looking for a way to configure the statsd prefix used by this agent.  Currently, it is hardcoded to use the full host name, but that does not work for me, because it needs to fit into a larger scheme of how statsd and graphite metrics are organized.

Here is a hackish patch that allows specifying the prefix as part of the agent arguments, like `localhost:8125@60/myprefix`.  I'm not fond of this syntax, it's just a demo.  Maybe this should be put into a more standard and flexible syntax like a URI?

Comments?