### PR TITLE
Remove hostname

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.github.lookout.metrics</groupId>
     <artifactId>agent</artifactId>
 
-    <version>1.2</version>
+    <version>1.3</version>
     <packaging>jar</packaging>
 
     <name>cassandra-statsd-reporter</name>

--- a/src/main/java/com/github/lookout/metrics/agent/ReportAgent.java
+++ b/src/main/java/com/github/lookout/metrics/agent/ReportAgent.java
@@ -12,17 +12,12 @@ import java.util.concurrent.TimeUnit;
 public class ReportAgent {
 
     public static void premain(final String agentArgs, final Instrumentation inst) {
-        String host;
-        try {
-            host = InetAddress.getLocalHost().getHostName();
-        } catch (UnknownHostException e) {
-            host = "unknown-host";
-        }
+        final String prefix = "cassandra";
 
         final String[] reportingHostPorts = (agentArgs != null) ? agentArgs.split(",") : new String[]{null};
         for (final String reportingHostPort : reportingHostPorts) {
             final HostPortInterval hostPortInterval = new HostPortInterval(reportingHostPort);
-            final StatsDClient client = new NonBlockingStatsDClient(host, hostPortInterval.getHost(), hostPortInterval.getPort());
+            final StatsDClient client = new NonBlockingStatsDClient(prefix, hostPortInterval.getHost(), hostPortInterval.getPort());
             final StatsdReporter reporter = new StatsdReporter(hostPortInterval, client);
             reporter.start(hostPortInterval.getInterval(), TimeUnit.SECONDS);
         }


### PR DESCRIPTION
This change just hardcodes the prefix to 'cassandra'. We should make the prefix configurable based on
either a passed in configuration string or the cluster name, but that's not as easy or urgent as this
change.
